### PR TITLE
Cooldown-based breakage chance for reloading 4.26mm

### DIFF
--- a/zscript/426ammo.txt
+++ b/zscript/426ammo.txt
@@ -119,7 +119,7 @@ class HD4mMag:HDMagAmmo{
 		}
 		owner.A_PlaySound("weapons/pocket",CHAN_BODY,frandom(0.1,0.6));
 		mags[mags.size()-1]++;
-		sh.breakChance += 10;
+		sh.breakChance += random(10, 20);
 		return true;
 	}
 	override void Consolidate(){

--- a/zscript/426ammo.txt
+++ b/zscript/426ammo.txt
@@ -102,8 +102,8 @@ class HD4mMag:HDMagAmmo{
 		return true;
 	}
 	override bool Insert(){
-		if(owner.countinv('SteadyHand') == 0) { owner.GiveInventory('SteadyHand'); }
-		let sh = owner.FindInventory('SteadyHand');
+		if(owner.countinv('SteadyHand') == 0) { owner.GiveInventory('SteadyHand', 1); }
+		let sh = SteadyHand(owner.FindInventory('SteadyHand'));
 		SyncAmount();
 		if(
 			mags[mags.size()-1]>=50

--- a/zscript/426ammo.txt
+++ b/zscript/426ammo.txt
@@ -102,6 +102,8 @@ class HD4mMag:HDMagAmmo{
 		return true;
 	}
 	override bool Insert(){
+		if(owner.countinv('SteadyHand') == 0) { owner.GiveInventory('SteadyHand'); }
+		let sh = owner.FindInventory('SteadyHand');
 		SyncAmount();
 		if(
 			mags[mags.size()-1]>=50
@@ -109,7 +111,7 @@ class HD4mMag:HDMagAmmo{
 		)return false;
 		owner.A_TakeInventory(roundtype,1,TIF_NOTAKEINFINITE);
 		owner.A_PlaySound("weapons/rifleclick2",CHAN_WEAPON);
-		if(!random(0,7)){
+		if(random(1,100) <= sh.breakChance){
 			owner.A_PlaySound("weapons/bigcrack",CHAN_BODY);
 			owner.A_SpawnItemEx("HDSmokeChunk",12,0,owner.height-12,4,frandom(-2,2),frandom(2,4));
 			owner.damagemobj(self,owner,1,"Thermal",DMG_NO_ARMOR);
@@ -117,6 +119,7 @@ class HD4mMag:HDMagAmmo{
 		}
 		owner.A_PlaySound("weapons/pocket",CHAN_BODY,frandom(0.1,0.6));
 		mags[mags.size()-1]++;
+		sh.breakChance += 10;
 		return true;
 	}
 	override void Consolidate(){
@@ -178,3 +181,10 @@ class HD4mmMagEmpty:IdleDummy{
 	}
 }
 
+class SteadyHand : Inventory {
+	int breakChance;
+	override void DoEffect() {
+		super.DoEffect();
+		breakChance = max(breakChance - 1, 1);
+	}
+}


### PR DESCRIPTION
First off, I don't expect this to get pulled as-is. I hacked it together blind over SSH while at work. Just wanted to offer a proof-of-concept.

# Description

This change adds a cooldown-based, stacking breakage chance when repacking 4.26mm magazines. Each time a round is loaded, a 10-20% chance of breakage is added, which then drops 1% every tic (to a minimum of 1%). This number range may need some tweaking, but ideally: 

* A very patient player should be able to reload 1-2 rounds per second with very little danger.
* A player that spams the reload key 2-4 times a second is likely to get frequent but not excessive breaks.
* A player that holds the reload key is probably going to break almost every single round they load after the first 3-5.

# Problems

The way of tracking the `breakChance` variable is likely not very good and would be better as a variable somewhere else on the player instead of an inventory item, for example. The breakage stacking or cooldown may need some tweaking. Otherwise I think it's pretty good in its current state. 

Please advise on any changes, I'll be happy to make them if it increases the chances of this change being pulled. 