### PR TITLE
Minor visual changes for incapacitation

### DIFF
--- a/zscript/playercrawl.txt
+++ b/zscript/playercrawl.txt
@@ -50,7 +50,7 @@ class HDPlayerDying:HDPlayerPawn{
 
 		viewbob=12.;
 		speed=min(speed,frandom(0,0.06));
-		if(pitch<70)A_MuzzleClimb((frandom(-0.1,0.1),frandom(0.1,0.6)),(0,0),(0,0),(0,0));
+		if(pitch<20)A_MuzzleClimb((frandom(-0.1,0.1),frandom(0.1,0.6)),(0,0),(0,0),(0,0));
 		else A_TakeInventory("IsMoving");
 		gunbraced=false;
 

--- a/zscript/playercrawl.txt
+++ b/zscript/playercrawl.txt
@@ -52,6 +52,7 @@ class HDPlayerDying:HDPlayerPawn{
 		speed=min(speed,frandom(0,0.06));
 		if(pitch<20)A_MuzzleClimb((frandom(-0.1,0.1),frandom(0.1,0.6)),(0,0),(0,0),(0,0));
 		else A_TakeInventory("IsMoving");
+		A_SetRoll(25 * sin(angle) * (cos(pitch)**2), SPF_INTERPOLATE);
 		gunbraced=false;
 
 		if(health>min(12,getmaxhealth()-1)){		


### PR DESCRIPTION
This pull request adds two commits to improve the visuals of crawling players somewhat.

* The first is to make the forced pitch-down less aggressive, stopping at pitch 20 instead of 70. This allows players to at least see a little without constantly dragging the mouse upwards. Unfortunately bandaging still forces the player to instantly look straight down, which is jarring regardless. I'd request that the bandaging system not do any forced pitch adjustment when incapacitated. 
* The second rolls the player's view based on `sin(angle)` (with an adjustment to be rolled less when pitched up or down). I believe this makes it feel more like the player is lying and rolling on the ground. As noted in the extended commit message, this would be better if it were based on angle from the last movement vector instead of raw angle, but I don't know if there's a variable that tracks that smoothly enough.

Feedback appreciated, I'll be happy to make adjustments on my end if needed prior to merging, if accepted. 