### PR TITLE
Rebalance Hell Knights and Revenants

### DIFF
--- a/zscript/mon/boner.zs
+++ b/zscript/mon/boner.zs
@@ -118,9 +118,11 @@ class Boner:HDMobBase replaces Revenant{
 		speed 14;
 		mass 200;
 		health 250;
+		hdmobbase.shields 200;
 		obituary "%o was bagged by a boner.";
 		hitobituary "%o was slapped by a boner.";
 		damagefactor "Thermal",1.1;
+		damagefactor "Piercing",0.7;
 		damagefactor "SmallArms0",0.9;
 		damagefactor "SmallArms1",0.9;
 		damagefactor "SmallArms2",0.8;

--- a/zscript/mon/painbringer.zs
+++ b/zscript/mon/painbringer.zs
@@ -18,12 +18,12 @@ class PainBringer:PainMonster replaces HellKnight{
 
 		damagefactor "Balefire",0.3;
 		damagefactor "Thermal",0.8;
-		hdmobbase.shields 500;
+		hdmobbase.shields 300;
 		scale 0.9;
 		speed 12;
 		meleedamage 10;
 		meleerange 56;
-		minmissilechance 42;
+		minmissilechance 64;
 
 		stamina 0;
 	}
@@ -112,7 +112,7 @@ class PainBringer:PainMonster replaces HellKnight{
 		}
 		---- A 0 setstatelabel("see");
 	fireball:
-		BOS2 FE 3 A_FaceTarget(60,60);
+		BOS2 FFE 3 A_FaceTarget(45,45);
 		BOS2 E 2{
 			A_FaceTarget(6,6);
 			targetingangle=angle;targetingpitch=pitch;
@@ -135,7 +135,7 @@ class PainBringer:PainMonster replaces HellKnight{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("BaleBall",
 				0,0,32,
-				cos(pitch)*25,0,-sin(pitch)*25
+				cos(pitch)*15,0,-sin(pitch)*15
 			);
 			aaa.vel+=vel;aaa.tracer=target;
 		}

--- a/zscript/mon/painbringer.zs
+++ b/zscript/mon/painbringer.zs
@@ -120,7 +120,7 @@ class PainBringer:PainMonster replaces HellKnight{
 		BOS2 E 3{
 			A_FaceTarget(6,6);
 
-			if(target&&targetdistance<(25*35*7)){
+			if(target&&targetdistance<(18*35*7)){
 				double adj=targetdistance*frandom(0.008,0.032);
 				angle+=deltaangle(targetingangle,angle)*adj;
 				if(target.bfloat)pitch+=deltaangle(targetingpitch,pitch)*adj;
@@ -135,7 +135,7 @@ class PainBringer:PainMonster replaces HellKnight{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("BaleBall",
 				0,0,32,
-				cos(pitch)*15,0,-sin(pitch)*15
+				cos(pitch)*18,0,-sin(pitch)*18
 			);
 			aaa.vel+=vel;aaa.tracer=target;
 		}


### PR DESCRIPTION
This hopefully should bring hell knights down to a more reasonable threat level and make revenants a bit less of a joke.

Hell knight:
- Shield amount reduced
- Attacks a bit less often
- Projectiles move slower
- 3 more tics for the player to react with its attack

Revenant:
- Takes a little less Piercing damage
- Has 200 shields now