### PR TITLE
scopecam: change angle adjustment from hudbob

### DIFF
--- a/zscript/player/player.zs
+++ b/zscript/player/player.zs
@@ -664,7 +664,7 @@ class ScopeCamera:IdleDummy{
 			destroy();
 			return;
 		}
-		A_SetAngle(hpl.angle-hpl.hudbob.x*0.27,SPF_INTERPOLATE);
+		A_SetAngle(hpl.angle-hpl.hudbob.x*0.54,SPF_INTERPOLATE);
 		A_SetPitch(hpl.pitch+hpl.hudbob.y*0.27,SPF_INTERPOLATE);
 		A_SetRoll(hpl.roll);
 		vector2 fwd=angletovector(angle,2);


### PR DESCRIPTION
While testing my "laser sight" for Ugly as Sin, I realized the scope camera doesn't seem to accurately match what the sights onscreen are doing. I'm not sure how the value `.27` was originally obtained, but this value does not hold true for all weapons. "Physical" sights like the pistol, shotguns, boss irons, etc, tend to badly overshoot, and reflex sights like the ZM *slightly* overshoot. In other words, the sight points "ahead" of the actual scope camera when turning. 

Hence, my initial doubling of the angle value (pitch appears fine). However, after changing this value, it appears the reflex sights on the rifles track less than the irons on most other guns, so with this value change they appear to lag behind the scope camera while the shotguns and pistol and SMG appear spot on.

I believe this is due to some math being applied to certain weaponsights, inconsistent with the scope camera sway. Perhaps the initial implementation of the ZM reflex was meant to point slightly ahead of the real angle, but later it was desired that the shotgun / pistol should move more in response to mouse movement and so the sight offsets relative to the scope bob were multiplied additionally, even though the scope camera is still doing the same movement under the hood. I'm not familiar enough with the code to determine exactly where this disconnect happens.

As-is, with my laser sight acting as a "debug" for the scope camera, I feel the angle multiplier of `0.54` and the pitch value of `0.27` are a better compromise that more accurately reflects what the player sees with iron sights, and perhaps the ZM / Lib reflex sights should have their bob offset multiplier increased. I'm open to suggestions and thoughts on this.