### PR TITLE
Proof of concept for circular scopes

### DIFF
--- a/zscript/wep/zm66.zs
+++ b/zscript/wep/zm66.zs
@@ -160,22 +160,26 @@ class ZM66AssaultRifle:HDWeapon{
 			if(scopeview){
 				double degree=(hdw.weaponstatus[ZM66S_ZOOM])*0.1;
 				texman.setcameratotexture(hpc,"HDXHCAM3",degree);
-				sb.drawimage(
-					"HDXHCAM3",(0,scaledyoffset)+bob,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
-					scale:(0.31,0.31)
-				);
-				int scaledwidth=57;
-				int cx,cy,cw,ch;
-				[cx,cy,cw,ch]=screen.GetClipRect();
-				sb.SetClipRect(
-					-28+bob.x,19+bob.y,scaledwidth,scaledwidth,
-					sb.DI_SCREEN_CENTER
-				);
-				sb.drawimage(
-					"scophole",(0,scaledyoffset)+bob*3,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
-					scale:(0.78,0.78)
-				);
-				sb.SetClipRect(cx,cy,cw,ch);
+
+				TextureID scope = TexMan.CheckForTexture("HDXHCAM3", TexMan.Type_Any);
+				TextureID scopehole = TexMan.CheckForTexture("scophole", TexMan.Type_Any);
+
+				// these values are hardcoded to my 1920x1080 screen and hud / scope
+				// scale but should represent the idea well enough
+				DrawCircle(
+					scope,
+					120,
+					(960,775)+bob * 6);
+
+				// this is commented out as the scope hole texture is too small
+				// when drawn at native resolution, and I haven't figured
+				// out how shape2D stuff is scaled.
+				// It shows working proof of concept however.
+				/*DrawCircle(
+					scopehole,
+					180,
+					(960,775)+bob * 6);*/
+
 				sb.drawimage(
 					"zm66scop",(0,scaledyoffset)+bob,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
 					scale:(0.82,0.82)
@@ -188,6 +192,34 @@ class ZM66AssaultRifle:HDWeapon{
 			}
 		}
 	}
+
+	// rad = radius of circle (using half width of texture is recommended)
+	// verts describes how detailed the circle of the scope is
+	// more verts = higher resolution circle but higher performance cost
+	ui void DrawCircle(TextureID id, double rad, Vector2 pos, uint verts = 32)
+    {
+        Shape2D circle = new("Shape2D");
+
+		double angStep = 360 / verts;
+		double ang;
+		for (uint i = 0; i < verts; ++i)
+		{
+			double c = cos(ang);
+			double s = sin(ang);
+
+			circle.PushCoord(((c+1)/2, (s+1)/2));
+
+			if (i+2 < verts)
+				circle.PushTriangle(0, i+1, i+2);
+
+			circle.PushVertex((c*rad + pos.x, s*rad + pos.y));
+
+			ang += angStep;
+		}
+
+		Screen.DrawShape(id, false, circle);
+    }
+
 	override double weaponbulk(){
 		double blx=90;
 		if(!(weaponstatus[0]&ZM66F_NOLAUNCHER)){


### PR DESCRIPTION
@Boondorl recently created a generic library for weapon zoomscopes, which I've determined can be (fairly) easily adapted to HD's scopes, allowing for true circular scope textures.

https://github.com/Boondorl/Weapon-Scopes/blob/master/zscript/scope.txt

![image](https://user-images.githubusercontent.com/6425795/80162449-a0560c00-8590-11ea-9c20-244c61fb374a.png)
(the scope view is drawn smaller than the reticle in this screenshot to show that it is indeed circular)

The key is this new function:
```
// rad = radius of circle (using half width of texture is recommended)
// verts describes how detailed the circle of the scope is
// more verts = higher resolution circle but higher performance cost
ui void DrawScope(TextureID id, double rad, Vector2 pos, uint verts = 32)
```
I've put this in the ZM66 itself for ease of reference, but it would probably be better placed in the weapon parent class

Things I haven't done in this proof of concept:

- Accounted for different screen sizes and hud/crosshair scales in the position / bobbing variables. It's all hardcoded to my hud scale and screen at 1920x1080
- Drawn the black "hole" overlay. This is drawn at native res instead of the hud/crosshair scale, and I'm not sure how to scale it up. The code can be uncommented to show that the overlay works properly otherwise.
- Formatted the shape drawing function to match HD's code style.

EDIT: I've realized the black scopehole overlay may not be possible in this form because the circular shape position would offset itself instead of clipping the offset texture. I'm pretty sure this problem is solvable, but might require someone with more knowledge of Shape2D drawing.