### PR TITLE
Small tweaks to 9mm and .355

### DIFF
--- a/zscript/bullet.zs
+++ b/zscript/bullet.zs
@@ -95,8 +95,8 @@ class HDB_776:HDBulletActor{
 class HDB_9:HDBulletActor{
 	default{
 		pushfactor 0.4;
-		mass 86;
-		speed 550;
+		mass 80;
+		speed 475;
 		accuracy 300;
 		stamina 900;
 		woundhealth 10;
@@ -109,7 +109,7 @@ class HDB_355:HDBulletActor{
 		mass 99;
 		speed 600;
 		accuracy 240;
-		stamina 890;
+		stamina 900;
 		woundhealth 15;
 		hdbulletactor.hardness 3;
 	}


### PR DESCRIPTION
As-is these rounds are virtually identical in terminal ballistics since the 9x22mm Parum is basically 9x29mm (!!!) Win Mag, and the .355 Masterball which is stated to be "more powerful" but is obviously modeled on .357 Magnum which itself is basically 9mm Win Mag for revolvers. Essentially these two rounds are indistinguishable as-is with a very very slight almost meaningless statistical edge to the .355. Additionally the 9mm seems to be treated ingame more like 9x19mm Para in terms of recoil.

Summary of tweaks:

1. Fix diameter of .355 (was actually closer to .350)
2. Reduce speed of 9mm to approx 1300fps / 415ms (hotter than 9mm Para but not nearly as hot as 9mm Win Mag)
3. Reduce weight of 9mm to approx 125 grains (slightly heavy for 9mm Para but not quite as heavy as before).

In essence, nerfed the 9mm slightly to make the difference between the rounds more meaningful. The net result is slightly reduced terminal performance on targets (about average 1 shot more to down a zed in my non-scientific testing), but still extremely viable due to the higher possible volume of fire with the autoloader and SMG. I believe this is more in line with the relative differences between the real-life rounds these are seemingly based on.