### PR TITLE
Handle passive collision with +NOBLOCKMAP instead of CanCollideWith override

### DIFF
--- a/zscript/bullet.zs
+++ b/zscript/bullet.zs
@@ -389,9 +389,6 @@ class HDBulletActor:HDActor{
 	void ApplyGravity(){
 		if(vel.z>BULLET_TERMINALVELOCITY)vel.z-=max(0.001,getgravity());
 	}
-	override bool cancollidewith(actor other,bool passive){
-		return !passive;
-	}
 	static HDBulletActor FireBullet(
 		actor caller,
 		class<HDBulletActor> type="HDBulletActor",

--- a/zscript/pickup.zs
+++ b/zscript/pickup.zs
@@ -175,11 +175,12 @@ class HDPickerUpper:Actor{
 	default{
 		+solid
 		+nogravity
+		+noblockmap
 		height 2;
 		radius 2;
 	}
 	override bool cancollidewith(actor other,bool passive){
-		return (!passive&&(inventory(other)||hdupk(other)));
+		return inventory(other)||hdupk(other);
 	}
 }
 


### PR DESCRIPTION
from ZDoom wiki:
"This object is excluded from passive collision
detection. Nothing else can run into a NOBLOCKMAP
object but the object itself can run into others."

CanCollideWith only checks actor/actor collisions.
Ignoring passive collisions in CanCollideWith
will not prevent the actor from colliding with
other moving entities, such as PolyObjects.