### PR TITLE
Update NVG shader to separate scanline res from render res

### DIFF
--- a/gldefs.txt
+++ b/gldefs.txt
@@ -6,6 +6,7 @@ HardwareShader PostProcess screen{
 	Uniform int u_resfactor
 	Uniform int u_hscan
 	Uniform int u_vscan
+	Uniform int u_scanfactor
 	Uniform float u_scanstrength
 	Uniform int u_posterize
 	Uniform vec3 u_posfilter

--- a/nitevis.fp
+++ b/nitevis.fp
@@ -23,7 +23,8 @@ int resfactor = u_resfactor;
 // scanstrength is thickness of lines (0 = none, 1.0 = stupid thicc)
 bool hscan = bool(u_hscan);
 bool vscan = bool(u_vscan);
-float scanstrength = u_scanstrength * (resfactor * 4.0);
+int scanfactor = u_scanfactor;
+float scanstrength = u_scanstrength * (u_scanfactor * 4.0);
 
 // Posterization / palette filter
 // This sets number of color levels
@@ -84,10 +85,9 @@ void main(){
 	if (exposure < 0) { color *= clamp(negfilter + (color * whiteclip), 0.0, 1.0); }
 
 	// Scanlines
-	// No scanlines at native resolution
-	if (resfactor > 1) {
-		color *= 1 - int(hscan) * pow((1.0/float(resfactor)) * mod(TexCoord.y * textureSize(InputTexture,0).y, resfactor), resfactor / scanstrength);
-		color *= 1 - int(vscan) * pow((1.0/float(resfactor)) * mod(TexCoord.x * textureSize(InputTexture,0).x, resfactor), resfactor / scanstrength);
+	if (scanfactor > 1) {
+		color *= 1 - int(hscan) * pow((1.0/float(scanfactor)) * mod(TexCoord.y * textureSize(InputTexture,0).y, scanfactor), scanfactor / scanstrength);
+		color *= 1 - int(vscan) * pow((1.0/float(scanfactor)) * mod(TexCoord.x * textureSize(InputTexture,0).x, scanfactor), scanfactor / scanstrength);
 	}
 
 	// Output

--- a/zscript/gadgets.zs
+++ b/zscript/gadgets.zs
@@ -435,7 +435,7 @@ extend class PortableLiteAmp {
 		int style = NVGStyle.GetInt();
 		switch (style) {
 			case 0: // Hideous (green/red)
-				resfactor=1;hscan=1;vscan=0;scanfactor=4;scanstrength=0.25;posterize=24;posfilter=(0,1,0);negfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
+				resfactor=1;hscan=1;vscan=0;scanfactor=6;scanstrength=0.1;posterize=24;posfilter=(0,1,0);negfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
 			case 1: // Analog (green/amber)
 				resfactor=5;hscan=1;vscan=0;scanfactor=resfactor;scanstrength=0.1;posterize=256;posfilter=(0.25,1.0,0.25);negfilter=(1.0,1.0,0.25);whiteclip=0.75;desat=0.0;break;
 			case 2: // Digital (green/amber)

--- a/zscript/gadgets.zs
+++ b/zscript/gadgets.zs
@@ -333,6 +333,7 @@ class PortableLiteAmp:HDMagAmmo replaces Infrared{
 				Shader.SetUniform1i(owner.player,"NiteVis","u_resfactor",resfactor);
 				Shader.SetUniform1i(owner.player,"NiteVis","u_hscan",hscan);
 				Shader.SetUniform1i(owner.player,"NiteVis","u_vscan",vscan);
+				Shader.SetUniform1i(owner.player,"NiteVis","u_scanfactor",scanfactor);
 				Shader.SetUniform1f(owner.player,"NiteVis","u_scanstrength",scanstrength);
 				Shader.SetUniform1i(owner.player,"NiteVis","u_posterize",posterize);
 				Shader.SetUniform3f(owner.player,"NiteVis","u_posfilter",posfilter);
@@ -425,7 +426,7 @@ class VisorLight:PointLight{
 extend class PortableLiteAmp {
 	transient CVar NVGStyle;
 	int style;
-	int resfactor,hscan,vscan,posterize;
+	int resfactor,scanfactor,hscan,vscan,posterize;
 	double scanstrength,whiteclip,desat;
 	vector3 posfilter,negfilter;
 
@@ -434,15 +435,15 @@ extend class PortableLiteAmp {
 		int style = NVGStyle.GetInt();
 		switch (style) {
 			case 0: // Hideous (green/red)
-				resfactor=4;hscan=1;vscan=0;scanstrength=0.25;posterize=24;posfilter=(0,1,0);negfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
+				resfactor=1;hscan=1;vscan=0;scanfactor=4;scanstrength=0.25;posterize=24;posfilter=(0,1,0);negfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
 			case 1: // Analog (green/amber)
-				resfactor=5;hscan=1;vscan=0;scanstrength=0.1;posterize=256;posfilter=(0.25,1.0,0.25);negfilter=(1.0,1.0,0.25);whiteclip=0.75;desat=0.0;break;
+				resfactor=5;hscan=1;vscan=0;scanfactor=resfactor;scanstrength=0.1;posterize=256;posfilter=(0.25,1.0,0.25);negfilter=(1.0,1.0,0.25);whiteclip=0.75;desat=0.0;break;
 			case 2: // Digital (green/amber)
-				resfactor=4;hscan=1;vscan=1;scanstrength=0.05;posterize=16;posfilter=(0.1,1.0,0.1);negfilter=(1.0,1.0,0.1);whiteclip=0.9;desat=0.0;break;
+				resfactor=4;hscan=1;vscan=1;scanfactor=resfactor;scanstrength=0.05;posterize=16;posfilter=(0.1,1.0,0.1);negfilter=(1.0,1.0,0.1);whiteclip=0.9;desat=0.0;break;
 			case 3: // Modern (blue-green/white)
-				resfactor=3;hscan=0;vscan=0;scanstrength=0.0;posterize=256;posfilter=(0.0,1.0,0.75);negfilter=(0.65,0.65,1.0);whiteclip=0.8;desat=0.0;break;
+				resfactor=3;hscan=0;vscan=0;scanfactor=resfactor;scanstrength=0.0;posterize=256;posfilter=(0.0,1.0,0.75);negfilter=(0.65,0.65,1.0);whiteclip=0.8;desat=0.0;break;
 			case 4: // Truecolor
-				resfactor=3;hscan=0;vscan=0;scanstrength=0.0;posterize=256;posfilter=(1.0,0.5,0.5);negfilter=(0.5,1.0,0.5);whiteclip=1.0;desat=0.5;break;
+				resfactor=3;hscan=0;vscan=0;scanfactor=resfactor;scanstrength=0.0;posterize=256;posfilter=(1.0,0.5,0.5);negfilter=(0.5,1.0,0.5);whiteclip=1.0;desat=0.5;break;
 		}
 	}
 }


### PR DESCRIPTION
This pull request adds a separate uniform to the nightvision shader, which can be used to control the scanline "resolution" separate from downsampling the player's actual vision resolution.

**Example screenshot** at full render resolution with 1/6th resolution scanlines.
![image](https://user-images.githubusercontent.com/6425795/88339464-4f70c380-ccf7-11ea-9f51-75c8584575de.png)

This has only been changed for the "Hideous" NVG style for now, all other styles have rendering resolution and scanline resolution equal. I will do some further tweaking later and make a separate pull request with some further tweaks, but in the meantime this should make the default NVG more usable.

(when merging, I recommend using the "squash" option as I didn't give descriptive commit names due to making edits in the GitHub web interface)