### PR TITLE
NVG: Remove "negative" filtering, split and adjust presets

### DIFF
--- a/menudef.txt
+++ b/menudef.txt
@@ -31,14 +31,15 @@ OptionValue "Autoaim"{
 	6, "Always"
 }
 OptionValue "NVGStyle"{
-	0, "Hideous (green/red)"
-	1, "Analog (green/amber)"
-	2, "Digital (green/amber)"
-	3, "Modern (blue-green/white)"
-	4, "Truecolor (red/green"
+	0, "Hideous Green"
+	1, "Hideous Red"
+	2, "Analog Green"
+	3, "Analog Amber"
+	4, "Digital Green"
+	5, "Digital Amber"
+	6, "Modern Green"
+	7, "Truecolor"
 }
-
-
 OptionValue "DoorBuster"{
 	0,"Allow all"
 	1,"Allow none"

--- a/nitevis.fp
+++ b/nitevis.fp
@@ -50,8 +50,9 @@ void main(){
 	// copy exposure uniform
 	float exp = max(abs(exposure), 1);
 
-	// Limit resfactor
+	// Limit resfactor and scanfactor
 	resfactor = max(resfactor, 1);
+	scanfactor = max(scanfactor, 1);
 
 	// Downsample coordinate system
 	vec2 res = TexCoord;

--- a/zscript/gadgets.zs
+++ b/zscript/gadgets.zs
@@ -337,7 +337,6 @@ class PortableLiteAmp:HDMagAmmo replaces Infrared{
 				Shader.SetUniform1f(owner.player,"NiteVis","u_scanstrength",scanstrength);
 				Shader.SetUniform1i(owner.player,"NiteVis","u_posterize",posterize);
 				Shader.SetUniform3f(owner.player,"NiteVis","u_posfilter",posfilter);
-				Shader.SetUniform3f(owner.player,"NiteVis","u_negfilter",negfilter);
 				Shader.SetUniform1f(owner.player,"NiteVis","u_whiteclip",whiteclip);
 				Shader.SetUniform1f(owner.player,"NiteVis","u_desat",desat);
 			}
@@ -380,8 +379,6 @@ class PortableLiteAmp:HDMagAmmo replaces Infrared{
 				double plitude=max(0,(am+abs(invoker.amplitude)));
 				if(plitude>NITEVIS_MAX)plitude-=(NITEVIS_MAX+5);
 				invoker.amplitude=invoker.amplitude<0?-plitude:plitude;
-			}else if(cmd&BT_ZOOM){
-				invoker.amplitude=-invoker.amplitude;
 			}else if(cmd&BT_USER3){
 				invoker.firsttolast();
 				int amt=invoker.mags[0];
@@ -434,16 +431,22 @@ extend class PortableLiteAmp {
 		if (!NVGStyle) NVGStyle = CVar.GetCVar("hd_nv_style",owner.player);
 		int style = NVGStyle.GetInt();
 		switch (style) {
-			case 0: // Hideous (green/red)
-				resfactor=1;hscan=1;vscan=0;scanfactor=6;scanstrength=0.1;posterize=24;posfilter=(0,1,0);negfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
-			case 1: // Analog (green/amber)
-				resfactor=5;hscan=1;vscan=0;scanfactor=resfactor;scanstrength=0.1;posterize=256;posfilter=(0.25,1.0,0.25);negfilter=(1.0,1.0,0.25);whiteclip=0.75;desat=0.0;break;
-			case 2: // Digital (green/amber)
-				resfactor=4;hscan=1;vscan=1;scanfactor=resfactor;scanstrength=0.05;posterize=16;posfilter=(0.1,1.0,0.1);negfilter=(1.0,1.0,0.1);whiteclip=0.9;desat=0.0;break;
-			case 3: // Modern (blue-green/white)
-				resfactor=3;hscan=0;vscan=0;scanfactor=resfactor;scanstrength=0.0;posterize=256;posfilter=(0.0,1.0,0.75);negfilter=(0.65,0.65,1.0);whiteclip=0.8;desat=0.0;break;
-			case 4: // Truecolor
-				resfactor=3;hscan=0;vscan=0;scanfactor=resfactor;scanstrength=0.0;posterize=256;posfilter=(1.0,0.5,0.5);negfilter=(0.5,1.0,0.5);whiteclip=1.0;desat=0.5;break;
+			case 0: // Hideous green
+				resfactor=1;hscan=1;vscan=0;scanfactor=8;scanstrength=0.1;posterize=24;posfilter=(0,1,0);whiteclip=0.25;desat=0.0;break;
+			case 1: // Hideous red
+				resfactor=1;hscan=1;vscan=0;scanfactor=8;scanstrength=0.1;posterize=24;posfilter=(1,0,0);whiteclip=0.25;desat=0.0;break;
+			case 2: // Analog green
+				resfactor=4;hscan=1;vscan=0;scanfactor=resfactor;scanstrength=0.1;posterize=256;posfilter=(0.25,1.0,0.25);whiteclip=0.6;desat=0.1;break;
+			case 3: // Analog amber
+				resfactor=4;hscan=1;vscan=0;scanfactor=resfactor;scanstrength=0.1;posterize=256;posfilter=(1.0,1.0,0.25);whiteclip=0.6;desat=0.1;break;
+			case 4: // Digital green
+				resfactor=3;hscan=1;vscan=1;scanfactor=resfactor;scanstrength=0.025;posterize=16;posfilter=(0.05,1.0,0.05);whiteclip=0.9;desat=0.0;break;
+			case 5: // Digital amber
+				resfactor=3;hscan=1;vscan=1;scanfactor=resfactor;scanstrength=0.025;posterize=16;posfilter=(1.0,1.0,0.05);whiteclip=0.9;desat=0.0;break;
+			case 6: // Modern green
+				resfactor=2;hscan=1;vscan=0;scanfactor=2;scanstrength=0.1;posterize=256;posfilter=(0.0,1.0,0.75);whiteclip=0.8;desat=0.0;break;
+			case 7: // Truecolor
+				resfactor=1;hscan=1;vscan=0;scanfactor=2;scanstrength=0.1;posterize=256;posfilter=(0.5,1.0,0.5);whiteclip=1.0;desat=0.5;break;
 		}
 	}
 }


### PR DESCRIPTION
Removed the option for "negative" color modes, split all presets to individual colors in the menu. Also tweaked the various presets somewhat to be more visually appealing/useful.