### PR TITLE
ScopeCamera tweak

### DIFF
--- a/zscript/player/player.zs
+++ b/zscript/player/player.zs
@@ -19,7 +19,7 @@ class HDPlayerPawn:PlayerPawn{
 	hdweapon lastweapon;
 	bool barehanded;
 	bool gunbraced;
-	
+
 	double overloaded;
 
 	bool mustwalk;bool cansprint;
@@ -667,17 +667,14 @@ class ScopeCamera:IdleDummy{
 		A_SetAngle(hpl.angle-hpl.hudbob.x*0.54,SPF_INTERPOLATE);
 		A_SetPitch(hpl.pitch+hpl.hudbob.y*0.27,SPF_INTERPOLATE);
 		A_SetRoll(hpl.roll);
-		vector2 fwd=angletovector(angle,0.3);
 
 		double cf=(!!hpl.player)?hpl.player.viewheight:HDCONST_PLAYERHEIGHT-6;
 
-		if(abs(pitch)>89)setxyz(hpl.pos+(
-			fwd*max(0.5,cos(pitch))*2,
-			sin(-pitch)*6+cf
-		));else setxyz(hpl.pos+(
-			fwd*cos(pitch)*6,
-			sin(-pitch)*6+cf
-		));
+		vector3 newpos = hpl.vec3Angle(
+			2 * cos(-hpl.pitch),
+			hpl.angle,
+			2 * sin(-hpl.pitch) + cf);
+		SetOrigin(newpos, true);
 	}
 }
 
@@ -729,7 +726,7 @@ extend class HDPlayerPawn{
 		haszerked=0;
 
 		bloodloss=0;
-		
+
 		A_Capacitated();
 
 		feetangle=angle;

--- a/zscript/player/player.zs
+++ b/zscript/player/player.zs
@@ -671,9 +671,9 @@ class ScopeCamera:IdleDummy{
 		double cf=(!!hpl.player)?hpl.player.viewheight:HDCONST_PLAYERHEIGHT-6;
 
 		vector3 newpos = hpl.vec3Angle(
-			2 * cos(-hpl.pitch),
+			1 * cos(-hpl.pitch) + 1 * abs(sin(-hpl.pitch)),
 			hpl.angle,
-			2 * sin(-hpl.pitch) + cf);
+			1 * sin(-hpl.pitch) + cf);
 		SetOrigin(newpos, true);
 	}
 }


### PR DESCRIPTION
Slightly change the formula for the scope camera to track the player's view motion. I noticed (while testing changes to the UaS laser module) that the scope camera was still doing some slightly odd movements (moving too high or too low in relation to pitch, for example). This should fix it so the camera is always precisely aligned with the player's view vector (and not require that `if` anymore). Also interpolates the camera position with `SetOrigin` (which means it should be portal-aware now too, for whatever extreme minor edge cases that may affect).