### PR TITLE
Add shield breaking for enemies

### DIFF
--- a/sndinfo.txt
+++ b/sndinfo.txt
@@ -285,7 +285,7 @@ misc/casing3       dsrifck2  $volume misc/casing3 0.2  $limit misc/casing 3
 misc/casing4       dsding    $volume misc/casing4 0.9  $limit misc/casing 4
 misc/ladder        dsbelt
 misc/boxtrapped    dsrifclk
-
+misc/mobshield     dsfwoosh
 
 
 //delimit some stock doom sounds

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -299,10 +299,11 @@ extend class HDMobBase{
 			}
 		}
 
-		//replenish shields
+		//replenish shields and handle breaking/unbreaking
 		if(shields<maxshields)shields++;
 		if(shields==0){
-			shields=2;console.printf("unbroke!");
+			if(hd_debug)console.printf(getclassname().." shield restored!");
+			shields=2;
 			for(int i=0;i<10;i++){
 				vector3 rpos=pos+(
 					random(-radius,radius),
@@ -316,7 +317,8 @@ extend class HDMobBase{
 			}
 		}
 		if(shields==1){
-			shields=-350;console.printf("broke!");
+			if(hd_debug)console.printf(getclassname().." shield broke to "..-(maxshields/2).."!");
+			shields=-(maxshields/2);
 			for(int i=0;i<10;i++){
 				vector3 rpos=pos+(
 					random(-radius,radius),
@@ -327,7 +329,6 @@ extend class HDMobBase{
 				spk.vel=(frandom(-2,2),frandom(-2,2),frandom(-2,2))+vel;
 			}
 		}
-		console.printf(""..shields);
 
 		//regeneration
 		if(!(level.time&(1|2|4|8|16|32|64|128|256|512)))GiveBody(1);

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -317,8 +317,8 @@ extend class HDMobBase{
 			}
 		}
 		if(shields==1){
-			if(hd_debug)console.printf(getclassname().." shield broke to "..-(maxshields/2).."!");
-			shields=-(maxshields/2);
+			if(hd_debug)console.printf(getclassname().." shield broke to "..-(maxshields*0.125).."!");
+			shields=-(maxshields*0.125);
 			for(int i=0;i<10;i++){
 				vector3 rpos=pos+(
 					random(-radius,radius),

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -303,6 +303,7 @@ extend class HDMobBase{
 		if(shields<maxshields)shields++;
 		if(shields==0){
 			if(hd_debug)console.printf(getclassname().." shield restored!");
+			A_StartSound("misc/mobshield", CHAN_BODY, CHANF_OVERLAP, 0.75);
 			shields=2;
 			for(int i=0;i<10;i++){
 				vector3 rpos=pos+(
@@ -318,6 +319,7 @@ extend class HDMobBase{
 		}
 		if(shields==1){
 			if(hd_debug)console.printf(getclassname().." shield broke to "..-(maxshields*0.125).."!");
+			A_StartSound("misc/mobshield", CHAN_BODY, CHANF_OVERLAP, 0.75);
 			shields=-(maxshields*0.125);
 			for(int i=0;i<10;i++){
 				vector3 rpos=pos+(

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -301,6 +301,9 @@ extend class HDMobBase{
 
 		//replenish shields
 		if(shields<maxshields)shields++;
+		if(shields==0){shields=5;console.printf("unbroke!");}
+		if(shields>0&&shields<5){shields=-175;console.printf("broke!");}
+		console.printf(""..shields);
 
 		//regeneration
 		if(!(level.time&(1|2|4|8|16|32|64|128|256|512)))GiveBody(1);

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -301,8 +301,8 @@ extend class HDMobBase{
 
 		//replenish shields
 		if(shields<maxshields)shields++;
-		if(shields==0){shields=5;console.printf("unbroke!");}
-		if(shields>0&&shields<5){shields=-175;console.printf("broke!");}
+		if(shields==0){shields=2;console.printf("unbroke!");}
+		if(shields==1){shields=-350;console.printf("broke!");}
 		console.printf(""..shields);
 
 		//regeneration

--- a/zscript/mon/mobdamage.zs
+++ b/zscript/mon/mobdamage.zs
@@ -301,8 +301,32 @@ extend class HDMobBase{
 
 		//replenish shields
 		if(shields<maxshields)shields++;
-		if(shields==0){shields=2;console.printf("unbroke!");}
-		if(shields==1){shields=-350;console.printf("broke!");}
+		if(shields==0){
+			shields=2;console.printf("unbroke!");
+			for(int i=0;i<10;i++){
+				vector3 rpos=pos+(
+					random(-radius,radius),
+					random(-radius,radius),
+					random(0,height)
+				);
+				actor spk=actor.spawn("ShieldSpark",rpos,ALLOW_REPLACE);
+				vector3 sv = spk.Vec3To(self);
+				sv.z += height/2;
+				spk.vel=(sv/50);
+			}
+		}
+		if(shields==1){
+			shields=-350;console.printf("broke!");
+			for(int i=0;i<10;i++){
+				vector3 rpos=pos+(
+					random(-radius,radius),
+					random(-radius,radius),
+					random(0,height)
+				);
+				actor spk=actor.spawn("ShieldSpark",rpos,ALLOW_REPLACE);
+				spk.vel=(frandom(-2,2),frandom(-2,2),frandom(-2,2))+vel;
+			}
+		}
 		console.printf(""..shields);
 
 		//regeneration


### PR DESCRIPTION
This pull request makes enemies with frag shields subject to a "shield break" effect. If the monster's shield is depleted, it disappears completely for a while (about half the length of time a full recharge would take). During this time, the monster is completely vulnerable to damage.

Testing indicates this doesn't actually change up the raw damage meta *that much* (a monster takes significant chunks of damage through low shields anyway). For example, a hellknight takes nearly two full ZM magazines to kill regardless. Obviously "shieldbuster" weapons like the 7mm and bronto aren't really affected.

What this *does* provide is better feedback for players that they're *actually* hurting the monsters (no sparks == full damage) and particularly makes shotguns feel more viable by tilting the meta towards fast partial reloads and re-breaking the monster's shield frequently (instead of retreating to fully reload for longer periods and having to completely start over on the shield, which feels very much like not making any progress at all).

Feedback appreciated, I'm marking as draft for now since this is an early first pass at this concept. I can implement any requested changes and mark ready for merge if it's well-received.